### PR TITLE
Fix saturation with new locally exclusive detection API

### DIFF
--- a/code/qc_utils.py
+++ b/code/qc_utils.py
@@ -1369,7 +1369,7 @@ def find_saturation_events(
     abs_thresholds = np.array([saturation_threshold_uv / gain] * num_channels)
     saturation_both.abs_thresholds = abs_thresholds
 
-    job_name = f"finding positive saturation events"
+    job_name = f"finding saturation events"
     squeeze_output = True
     nodes = [saturation_both]
 

--- a/code/qc_utils.py
+++ b/code/qc_utils.py
@@ -1362,13 +1362,17 @@ def find_saturation_events(
     num_channels = recording.get_num_channels()
 
     # here we set absolute thresholds externally, since we know the saturation thresholds
-    saturation_both = LocallyExclusivePeakDetector(recording, noise_levels=np.ones(num_channels))
-    abs_thresholds = np.array([saturation_threshold_uv / recording.get_channel_gains()[0]] * num_channels)
-    saturation_both.args = ("both", abs_thresholds, exclude_sweep_ms, neighbours_mask)
+    saturation_both = LocallyExclusivePeakDetector(
+        recording, noise_levels=np.ones(num_channels), peak_sign="both", exclude_sweep_ms=exclude_sweep_ms
+    )
+    gain = recording.get_channel_gains()[0]
+    abs_thresholds = np.array([saturation_threshold_uv / gain] * num_channels)
+    saturation_both.abs_thresholds = abs_thresholds
 
-    job_name = f"finding saturation events"
+    job_name = f"finding positive saturation events"
     squeeze_output = True
     nodes = [saturation_both]
+
     outs = run_node_pipeline(
         recording,
         nodes,


### PR DESCRIPTION
Fixes a bug introduced in SI v0.103.2, where the `LocallyExclusivePeakDetector` internal machinery changed, preventing the arguments used by the saturation function to be propagated to the internal detection machinery